### PR TITLE
New jenkins plugin fails with confusing message when used with older IQ Servers CLM-10117 CLM-10103 

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -56,7 +56,7 @@ class IqPolicyEvaluatorUtil
       }
       catch (IqClientException e) {
         if (isHttp404Error(e)) {
-          listener.logger.println Messages._IqPolicyEvaluation_ResourceNotFound()
+          listener.logger.println Messages._IqPolicyEvaluation_AutoAppMissing()
           run.result = Result.FAILURE
           return null
         }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -24,6 +24,7 @@ import hudson.Launcher
 import hudson.model.Result
 import hudson.model.Run
 import hudson.model.TaskListener
+import org.apache.commons.httpclient.HttpStatus
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.http.client.HttpResponseException
 
@@ -116,7 +117,7 @@ class IqPolicyEvaluatorUtil
     if (httpResponseExceptionIndex >= 0) {
       Throwable[] throwables = ExceptionUtils.getThrowables(throwable)
       HttpResponseException httpResponseException = (HttpResponseException) throwables[httpResponseExceptionIndex]
-      return httpResponseException.statusCode == 404
+      return httpResponseException.statusCode == HttpStatus.SC_NOT_FOUND
     }
     return false
   }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -112,16 +112,13 @@ class IqPolicyEvaluatorUtil
   }
 
   private static boolean isHttp404Error(final Exception throwable) {
-    boolean result = false
     int httpResponseExceptionIndex = ExceptionUtils.indexOfType(throwable, HttpResponseException)
     if (httpResponseExceptionIndex >= 0) {
       Throwable[] throwables = ExceptionUtils.getThrowables(throwable)
       HttpResponseException httpResponseException = (HttpResponseException) throwables[httpResponseExceptionIndex]
-      if (httpResponseException.statusCode == 404) {
-        result = true
-      }
+      return httpResponseException.statusCode == 404
     }
-    return result
+    return false
   }
 
   private static boolean isNetworkError(final Exception throwable) {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -30,7 +30,7 @@ IqPolicyEvaluation.FailOnNetwork=Fail build when unable to communicate with IQ S
 IqPolicyEvaluation.JobSpecificCredentials=Use job specific credentials
 
 IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.
-IqPolicyEvaluation.ResourceNotFound=Possible version mismatch.  Please check if the IQ Server is compatible with this plugin.
+IqPolicyEvaluation.ResourceNotFound=Possible version mismatch. Please check if the IQ Server is compatible with this plugin version.
 
 IqPolicyEvaluation.EvaluationFailed=IQ Server evaluation of application {0} failed
 IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} detected warnings

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -30,7 +30,7 @@ IqPolicyEvaluation.FailOnNetwork=Fail build when unable to communicate with IQ S
 IqPolicyEvaluation.JobSpecificCredentials=Use job specific credentials
 
 IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.
-IqPolicyEvaluation.ResourceNotFound=Possible version mismatch. Please check if the IQ Server is compatible with this plugin version.
+IqPolicyEvaluation.AutoAppMissing=Missing Auto App Creation.  Possible version mismatch. Please check if the IQ Server is compatible with this plugin version.  Supported IQ server versions are 1.45.0 or newer.
 
 IqPolicyEvaluation.EvaluationFailed=IQ Server evaluation of application {0} failed
 IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} detected warnings

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -30,7 +30,7 @@ IqPolicyEvaluation.FailOnNetwork=Fail build when unable to communicate with IQ S
 IqPolicyEvaluation.JobSpecificCredentials=Use job specific credentials
 
 IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.
-IqPolicyEvaluation.AutoAppMissing=Missing Auto App Creation.  Possible version mismatch. Please check if the IQ Server is compatible with this plugin version.  Supported IQ server versions are 1.45.0 or newer.
+IqPolicyEvaluation.AutoAppMissing=Missing Auto App Creation. Possible version mismatch. Please check if the IQ Server is compatible with this plugin version. Supported IQ server versions are 1.45.0 or newer.
 
 IqPolicyEvaluation.EvaluationFailed=IQ Server evaluation of application {0} failed
 IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} detected warnings

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -30,6 +30,7 @@ IqPolicyEvaluation.FailOnNetwork=Fail build when unable to communicate with IQ S
 IqPolicyEvaluation.JobSpecificCredentials=Use job specific credentials
 
 IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.
+IqPolicyEvaluation.ResourceNotFound=Possible version mismatch.  Please check if the IQ Server is compatible with this plugin.
 
 IqPolicyEvaluation.EvaluationFailed=IQ Server evaluation of application {0} failed
 IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} detected warnings

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -32,6 +32,7 @@ import hudson.model.Run
 import hudson.model.TaskListener
 import hudson.remoting.Channel
 import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.http.client.HttpResponseException
 import org.slf4j.Logger
 import spock.lang.Specification
 import spock.util.mop.ConfineMetaClassChanges
@@ -393,5 +394,31 @@ class IqPolicyEvaluatorTest
       0 * log.println("WARNING: IQ Server evaluation of application appId detected warnings.")
       1 * log.println('\nThe detailed report can be viewed online at http://server/report\n' +
           'Summary of policy violations: 0 critical, 0 severe, 0 moderate')
+  }
+
+  def 'Resource not found exception handling'() {
+    setup:
+      iqClient.verifyOrCreateApplication(*_) >> { throw exception }
+      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'),
+          [new ScanPattern('*.jar')], [],
+          failBuildOnNetworkError, '131-cred')
+      PrintStream logger = Mock()
+      TaskListener listener = Mock() {
+        getLogger() >> logger
+      }
+
+    when:
+      buildStep.perform(run, workspace, launcher, listener)
+
+    then:
+      noExceptionThrown()
+      1 * run.setResult(Result.FAILURE)
+      1 * logger.println({ Messages._IqPolicyEvaluation_ResourceNotFound().toString() })
+
+    where:
+      exception                                         | failBuildOnNetworkError || expectedException | expectedMessage
+      new IqClientException('BOOM!!',
+          new IOException('CRASH',
+              new HttpResponseException(404, 'CRASH'))) | false                   || null              | ''
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -396,7 +396,7 @@ class IqPolicyEvaluatorTest
           'Summary of policy violations: 0 critical, 0 severe, 0 moderate')
   }
 
-  def 'Resource not found exception handling'() {
+  def 'Auto App Creation not supported by IQ Server'() {
     setup:
       iqClient.verifyOrCreateApplication(*_) >> { throw exception }
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'),

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -413,7 +413,7 @@ class IqPolicyEvaluatorTest
     then:
       noExceptionThrown()
       1 * run.setResult(Result.FAILURE)
-      1 * logger.println({ Messages._IqPolicyEvaluation_ResourceNotFound().toString() })
+      1 * logger.println({ Messages._IqPolicyEvaluation_AutoAppMissing().toString() })
 
     where:
       exception                                         | failBuildOnNetworkError || expectedException | expectedMessage


### PR DESCRIPTION
Provide an error message when the IQ server and Jenkins plugin are not compatible.

https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-10103_Need_better_msg_for_unsupported_IQ/

https://issues.sonatype.org/browse/CLM-10117