### PR TITLE
Update the version of nexus-java-api with auto app error message CLM-10118 CLM-10103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.0.20180316-144803.5dbd636</version>
+        <version>3.1.20180525-134038.ced2ef5</version>
         <classifier>internal</classifier>
       </dependency>
 


### PR DESCRIPTION
Update the nexus-java-api reference to the version which has the auto app creation error message when it is communicating which an unsupported version of the IQ Server.

https://issues.sonatype.org/browse/CLM-10118
https://issues.sonatype.org/browse/CLM-10103

https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-10118_Better_Msg_For_Auto_App_Missing/

Build failure nothing to do with PR.  Looks to be a Build server configuration issue.
